### PR TITLE
Switch collection config from dict to list (fixes #11)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,11 @@
+Changelog
+=========
+
+This document describes changes between each past release.
+
+0.1.0 (unreleased)
+----------------
+
+**Initial version**
+
+- Use a list of hooks to configure emails bound to notifications (fixes #11)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,0 +1,5 @@
+Contributors
+============
+
+* Rémy Hubscher <rhubscher@mozilla.com>
+* Mathieu Leplatre <mathieu@mozilla.com>

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,5 +1,6 @@
 Contributors
 ============
 
+* Alexis Métaireau <alexis@notmyidea.org>
 * Rémy Hubscher <rhubscher@mozilla.com>
 * Mathieu Leplatre <mathieu@mozilla.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017 - Mozilla Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 - Mozilla Foundation
+Copyright 2017 - Mozilla Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.rst LICENSE Makefile

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,13 @@ The following examples are defined on buckets:
 
   {
     "kinto-emailer": {
-      "record.create": {
+      "hooks": [{
+        "resource_name": "record",
+        "action": "create",
         "template": "Hi, a new record '{uri}' has just been created in the collection '{bucket_id}/{collection_id}'",
         "recipients": ['Security reviewers <security-reviews@mozilla.com>'],
         "sender": "Kinto team <developers@kinto-storage.org>"
-      }
+      }]
     }
   }
 

--- a/kinto_emailer/__init__.py
+++ b/kinto_emailer/__init__.py
@@ -8,13 +8,6 @@ def send_notification(event):
     payload = event.payload
     storage = event.request.registry.storage
 
-    resource_name = payload['resource_name']
-    action = payload.get('action')
-    is_record = resource_name == 'record'
-    is_collection_update = resource_name == 'collection' and action == 'update'
-    if not is_record and not is_collection_update:
-        return
-
     collection_record = get_collection_record(storage,
                                               payload['bucket_id'],
                                               payload['collection_id'])
@@ -63,10 +56,6 @@ def includeme(config):
     docs = "https://github.com/Kinto/kinto-emailer/"
     config.add_api_capability("emailer", message, docs)
 
-    # Listen to resource change events, to check if a new signature is
-    # requested.
-    config.add_subscriber(
-        send_notification,
-        AfterResourceChanged,
-        for_actions=('create', 'update', 'delete'),
-        for_resources=('record', 'collection'))
+    # Listen to collection and record change events.
+    config.add_subscriber(send_notification, AfterResourceChanged,
+                          for_resources=('record', 'collection'))

--- a/kinto_emailer/__init__.py
+++ b/kinto_emailer/__init__.py
@@ -31,6 +31,8 @@ def get_messages(collection_record, payload):
     hooks = collection_record.get('kinto-emailer', {}).get('hooks', [])
     messages = []
     for hook in hooks:
+        # Filter out hook if it doesn't meet current event attributes, and keep
+        # if nothing is specified.
         conditions_met = all([field not in hook or field not in payload or
                               hook[field] == payload[field]
                               for field in ('action', 'resource_name', 'id')])

--- a/kinto_emailer/__init__.py
+++ b/kinto_emailer/__init__.py
@@ -8,9 +8,9 @@ def send_notification(event):
     payload = event.payload
     storage = event.request.registry.storage
 
-    collection_record = get_collection_record(storage,
-                                              payload['bucket_id'],
-                                              payload['collection_id'])
+    collection_record = _get_collection_record(storage,
+                                               payload['bucket_id'],
+                                               payload['collection_id'])
     message = get_message(collection_record, payload)
 
     if message:
@@ -18,7 +18,7 @@ def send_notification(event):
         mailer.send(message)
 
 
-def get_collection_record(storage, bucket_id, collection_id):
+def _get_collection_record(storage, bucket_id, collection_id):
     parent_id = '/buckets/%s' % bucket_id
     record_type = 'collection'
 

--- a/kinto_emailer/__init__.py
+++ b/kinto_emailer/__init__.py
@@ -31,8 +31,9 @@ def get_messages(collection_record, payload):
     hooks = collection_record.get('kinto-emailer', {}).get('hooks', [])
     messages = []
     for hook in hooks:
-        conditions_met = all([hook.get(field, payload[field]) == payload[field]
-                              for field in ('action', 'resource_name')])
+        conditions_met = all([field not in hook or field not in payload or
+                              hook[field] == payload[field]
+                              for field in ('action', 'resource_name', 'id')])
         if not conditions_met:
             continue
 

--- a/kinto_emailer/tests/functional.py
+++ b/kinto_emailer/tests/functional.py
@@ -49,11 +49,13 @@ class FunctionalTest(unittest.TestCase):
         self.client.create_bucket()
         self.client.create_collection(data={
             "kinto-emailer": {
-                'record.create': {
+                'hooks': [{
+                    "resource_name": "record",
+                    "action": "create",
                     "subject": "New email",
                     "template": "New {bucket_id}/{collection_id}/{record_id}.",
                     "recipients": ['kinto-emailer@restmail.net'],
-                }
+                }]
             }
         })
 

--- a/kinto_emailer/tests/test_includeme.py
+++ b/kinto_emailer/tests/test_includeme.py
@@ -15,12 +15,14 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 COLLECTION_RECORD = {
     'kinto-emailer': {
-        'record.update': {
+        'hooks': [{
+            'resource_name': 'record',
+            'action': 'update',
             'sender': 'kinto@restmail.net',
             'subject': 'Configured subject',
             'template': 'Bonjour les amis.',
             'recipients': ['kinto-emailer@restmail.net'],
-        }
+        }]
     }
 }
 
@@ -94,18 +96,17 @@ class PluginTest(unittest.TestCase):
     def test_get_message_returns_a_configured_message_for_collection_update(self):
         collection_record = {
             'kinto-emailer': {
-                'collection.update': {
+                'hooks': [{
                     'sender': 'kinto@restmail.net',
                     'subject': 'Configured subject',
                     'template': 'Bonjour les amis on collection update.',
                     'recipients': ['kinto-emailer@restmail.net'],
-                }
+                }]
             }
         }
 
-        message = get_message(collection_record,
-                              {'resource_name': 'collection',
-                               'action': 'update'})
+        payload = {'resource_name': 'collection', 'action': 'update'}
+        message = get_message(collection_record, payload)
 
         assert message.subject == 'Configured subject'
         assert message.sender == 'kinto@restmail.net'
@@ -120,17 +121,15 @@ class PluginTest(unittest.TestCase):
     def test_get_message_returns_default_subject_to_new_message(self):
         collection_record = {
             'kinto-emailer': {
-                'record.update': {
+                'hooks': [{
                     'sender': 'kinto@restmail.net',
                     'template': 'Bonjour les amis.',
                     'recipients': ['kinto-emailer@restmail.net'],
-                }
+                }]
             }
         }
-
-        message = get_message(collection_record,
-                              {'resource_name': 'record',
-                               'action': 'update'})
+        payload = {'resource_name': 'record', 'action': 'update'}
+        message = get_message(collection_record, payload)
 
         assert message.subject == 'New message'
 

--- a/kinto_emailer/tests/test_includeme.py
+++ b/kinto_emailer/tests/test_includeme.py
@@ -146,14 +146,6 @@ class PluginTest(unittest.TestCase):
             parent_id='/buckets/default',
             object_id='foobar')
 
-    def test_send_notification_ignore_non_record_events(self):
-        event = mock.MagicMock()
-        event.payload = {'resource_name': 'bucket'}
-
-        with mock.patch('kinto_emailer.get_collection_record') as mocked:
-            send_notification(event)
-            assert not mocked.called
-
     def test_send_notification_does_not_call_the_mailer_if_no_message(self):
         event = mock.MagicMock()
         event.payload = {

--- a/kinto_emailer/tests/test_includeme.py
+++ b/kinto_emailer/tests/test_includeme.py
@@ -131,6 +131,59 @@ class GetMessagesTest(unittest.TestCase):
 
         assert len(messages) == 2
 
+    def test_get_messages_can_filter_by_id(self):
+        collection_record = {
+            'kinto-emailer': {
+                'hooks': [{
+                    'id': 'poll',
+                    'template': 'Poll changed.',
+                    'recipients': ['me@you.com'],
+                }]
+            }
+        }
+        payload = {'resource_name': 'record', 'action': 'update', 'id': 'abc'}
+        messages = get_messages(collection_record, payload)
+
+        assert len(messages) == 0
+
+    def test_get_messages_ignores_resource_if_not_specified(self):
+        collection_record = {
+            'kinto-emailer': {
+                'hooks': [{
+                    'template': 'Poll changed.',
+                    'recipients': ['me@you.com'],
+                }]
+            }
+        }
+
+        payload = {'resource_name': 'record', 'action': 'update'}
+        messages = get_messages(collection_record, payload)
+        assert len(messages) == 1
+
+        payload = {'resource_name': 'collection', 'action': 'update'}
+        messages = get_messages(collection_record, payload)
+        assert len(messages) == 1
+
+    def test_get_messages_ignores_action_if_not_specified(self):
+        collection_record = {
+            'kinto-emailer': {
+                'hooks': [{
+                    'template': 'Poll changed.',
+                    'recipients': ['me@you.com'],
+                }]
+            }
+        }
+
+        payload = {'resource_name': 'record', 'action': 'create'}
+        messages = get_messages(collection_record, payload)
+        assert len(messages) == 1
+
+        payload = {'resource_name': 'record', 'action': 'update'}
+        messages = get_messages(collection_record, payload)
+        assert len(messages) == 1
+
+
+
 class SendNotificationTest(unittest.TestCase):
     def test_send_notification_does_not_call_the_mailer_if_no_message(self):
         event = mock.MagicMock()

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,19 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
-    README = f.read()
+def read_file(filename):
+    """Open a related file and return its content."""
+    with codecs.open(os.path.join(here, filename), encoding='utf-8') as f:
+        content = f.read()
+    return content
+
+README = read_file('README.rst')
+CHANGELOG = read_file('CHANGELOG.rst')
+CONTRIBUTORS = read_file('CONTRIBUTORS.rst')
+
 
 REQUIREMENTS = [
-    'kinto',
+    'kinto>5',
     'pyramid<1.8',
     'pyramid_mailer',
 ]
@@ -16,7 +24,7 @@ REQUIREMENTS = [
 setup(name='kinto-emailer',
       version='0.1.0.dev0',
       description='Kinto emailer plugin',
-      long_description=README,
+      long_description=README + "\n\n" + CHANGELOG + "\n\n" + CONTRIBUTORS,
       license='Apache License (2.0)',
       classifiers=[
           "Programming Language :: Python",


### PR DESCRIPTION
Fixes #11 

* [x] Switch from dict to list
* [x] Send several messages on one action
* [x] Add test when resource_name or action are not specified
* [x] Add test with additional filter like `record_id`