### PR TITLE
Fix failing test

### DIFF
--- a/kinto_emailer/tests/test_includeme.py
+++ b/kinto_emailer/tests/test_includeme.py
@@ -390,6 +390,7 @@ class SignerEventsTest(EmailerTest):
         self.addCleanup(patch.stop)
         mocked = patch.start()
         mocked.post.return_value.json.return_value = [{
+            "ref": "",
             "signature": "",
             "hash_algorithm": "",
             "signature_encoding": "",


### PR DESCRIPTION
As a result of https://github.com/Kinto/kinto-signer/pull/689, the tests here started failing. See for example #128, #129, #130.