### PR TITLE
Remove check of about template variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
-python: 3.6
+python: 3.8
 env:
-    - TOX_ENV=py36
+    - TOX_ENV=py38
     - TOX_ENV=kinto-master
     - TOX_ENV=flake8
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ This document describes changes between each past release.
 1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove template variable validation
 
 
 1.1.0 (2019-02-20)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ OBJECTS = .venv .coverage
 
 all: install
 install: $(INSTALL_STAMP)
-$(INSTALL_STAMP): $(PYTHON) setup.py
+$(INSTALL_STAMP): $(PYTHON) requirements.txt setup.py
+	$(VENV)/bin/pip install -r requirements.txt
 	$(PYTHON) setup.py develop
 	touch $(INSTALL_STAMP)
 

--- a/kinto_emailer/__init__.py
+++ b/kinto_emailer/__init__.py
@@ -161,16 +161,9 @@ def _validate_emailer_settings(event):
 
         for hook in hooks:
             try:
-                template = hook['template']
+                hook['template']
             except KeyError:
                 raise_invalid(request, description='Missing "template".')
-
-            try:
-                context = context_from_event(event)
-                template.format(**context)
-            except KeyError as e:
-                error_msg = 'Invalid template variable: %s' % e
-                raise_invalid(request, description=error_msg)
 
             recipients = hook.get('recipients', [])
             if not recipients:

--- a/kinto_emailer/tests/test_includeme.py
+++ b/kinto_emailer/tests/test_includeme.py
@@ -558,12 +558,3 @@ class HookValidationTest(FormattedErrorMixin, EmailerTest):
                               headers=self.headers,
                               status=400)
         assert 'Invalid recipients /buckets/b/group/g' in r.json['message']
-
-    def test_fails_if_template_contains_bad_placeholders(self):
-        tpl = 'The current temperature is {degres}C.'
-        self.valid_collection['kinto-emailer']['hooks'][0]['template'] = tpl
-        r = self.app.put_json('/buckets/b/collections/c',
-                              {'data': self.valid_collection},
-                              headers=self.headers,
-                              status=400)
-        assert 'degres' in r.json['message']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,kinto-master,flake8,functional
+envlist = py38,kinto-master,flake8,functional
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
It is irrelevant to test that an email template is valid against a ResourceEvent, since any kind of events is supported. 