### PR TITLE
Group dependencies pull-requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
-  ignore:
-  - dependency-name: idna
-    versions:
-    - ">= 3.1.a, < 3.2"
-  - dependency-name: pyramid
-    versions:
-    - ">= 2.0.a, < 2.1"
-  - dependency-name: zope-interface
-    versions:
-    - 5.2.0
-    - 5.3.0
-  - dependency-name: jsonpatch
-    versions:
-    - "1.31"
-  - dependency-name: pyramid
-    versions:
-    - 1.10.7
-  - dependency-name: cornice
-    versions:
-    - 5.1.0
+  groups:
+    all-dependencies:
+      update-types: ["major", "minor", "patch"]


### PR DESCRIPTION
Since this repository is a library, we don't necessarily need individual pull-requests for dependencies