### PR TITLE
Fix crash of `ValueError expected txn status 'Active' or 'Doomed', but it's 'Committed'`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,26 @@ jobs:
   functional-tests:
     needs: lint
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v4
+
+      - name: Create database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres -h localhost
 
       - uses: actions/setup-python@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ clean:
 	rm -rf $(VENV) mail/ *.egg-info .pytest_cache .ruff_cache .coverage build dist
 
 run-kinto: install
-	$(VENV)/bin/kinto start --ini tests/config/kinto.ini
+	$(VENV)/bin/kinto migrate --ini tests/config/functional.ini
+	$(VENV)/bin/kinto start --ini tests/config/functional.ini
 
 need-kinto-running:
 	@curl http://localhost:8888/v0/ 2>/dev/null 1>&2 || (echo "Run 'make run-kinto' before starting tests." && exit 1)

--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,24 @@ To run the unit tests::
 
   $ make tests
 
-For the functional tests, run a Kinto instance in a separate terminal::
+Functional Tests
+''''''''''''''''
+
+A PostgreSQL database is required.
+
+Install and run PostgreSQL using your system package manager, or using Docker:
+
+::
+
+  $ docker run -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:15
+
+Create the test database:
+
+::
+
+  $ psql -c "CREATE DATABASE testdb ENCODING 'UTF8' TEMPLATE template0;" -U postgres -h localhost -p 5432
+
+Run a Kinto instance in a separate terminal::
 
   $ make run-kinto
 
@@ -185,6 +202,11 @@ And start the test suite::
 
   $ make functional
 
+.. note::
+
+    If you need to run PostgreSQL on a different user, password, or port than the default, then specify DB URL when running ``make run-kinto``::
+
+      $ KINTO_STORAGE_URL="postgresql://username:password@host:6666/dbname" make run-kinto
 
 Releasing
 =========

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ To run the unit tests::
   $ make tests
 
 Functional Tests
-''''''''''''''''
+----------------
 
 A PostgreSQL database is required.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 dev = [
     "ruff",
+    "kinto[postgresql]",
     "kinto-client",
     "kinto-signer",
     "mock",

--- a/tests/config/functional.ini
+++ b/tests/config/functional.ini
@@ -1,0 +1,18 @@
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888
+
+[app:main]
+use = egg:kinto
+kinto.userid_hmac_secret = some-secret-string
+multiauth.policies = basicauth
+kinto.bucket_create_principals = system.Everyone
+
+kinto.storage_backend = kinto.core.storage.postgresql
+kinto.storage_url = postgresql://postgres:postgres@localhost/testdb
+
+kinto.includes = kinto.plugins.flush
+                 kinto_emailer
+mail.debug_mailer = true
+mail.default_sender = kinto@restmail.net

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -30,11 +30,15 @@ class FunctionalTest(unittest.TestCase):
             bucket=self._bucket,
             collection=self._collection,
         )
+        # Since we use a PG database that can contain objects, start clean.
+        self._flush_server(self._server_url)
 
     def tearDown(self):
         # Delete all the created objects.
         self._flush_server(self._server_url)
+        # Delete all files but keep the folder for next runs.
         shutil.rmtree("mail/", ignore_errors=True)
+        os.makedirs("mail/")
 
     def _flush_server(self, server_url):
         flush_url = urljoin(server_url, "/__flush__")

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -1,4 +1,3 @@
-import configparser
 import os.path
 import shutil
 import unittest
@@ -18,9 +17,6 @@ DEFAULT_AUTH = ("user", "p4ssw0rd")
 class FunctionalTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(FunctionalTest, self).__init__(*args, **kwargs)
-
-        self.emailer_config = configparser.RawConfigParser()
-        self.emailer_config.read(os.path.join(__HERE__, "config/kinto.ini"))
 
         # Setup the kinto clients for the source and destination.
         self._auth = DEFAULT_AUTH

--- a/tests/test_includeme.py
+++ b/tests/test_includeme.py
@@ -8,7 +8,7 @@ from kinto.core import errors
 from kinto.core.events import AfterResourceChanged
 from kinto.core.testing import BaseWebTest, FormattedErrorMixin, get_user_headers
 
-from kinto_emailer import context_from_event, get_messages, send_notification
+from kinto_emailer import context_from_event, get_messages, build_notification, send_notification
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -333,6 +333,7 @@ class SendNotificationTest(unittest.TestCase):
         event.request.registry.storage.get.return_value = {}
 
         with mock.patch("kinto_emailer.get_mailer") as get_mailer:
+            build_notification(event)
             send_notification(event)
             assert not get_mailer().send_immediately.called
 
@@ -349,6 +350,7 @@ class SendNotificationTest(unittest.TestCase):
         event.request.registry.settings = {}
 
         with mock.patch("kinto_emailer.get_mailer") as get_mailer:
+            build_notification(event)
             send_notification(event)
             assert get_mailer().send_immediately.called
 
@@ -365,6 +367,7 @@ class SendNotificationTest(unittest.TestCase):
         event.request.registry.settings = {"mail.queue_path": "/var/mail"}
 
         with mock.patch("kinto_emailer.get_mailer") as get_mailer:
+            build_notification(event)
             send_notification(event)
             assert get_mailer().send_to_queue.called
 

--- a/tests/test_includeme.py
+++ b/tests/test_includeme.py
@@ -8,7 +8,7 @@ from kinto.core import errors
 from kinto.core.events import AfterResourceChanged
 from kinto.core.testing import BaseWebTest, FormattedErrorMixin, get_user_headers
 
-from kinto_emailer import context_from_event, get_messages, build_notification, send_notification
+from kinto_emailer import build_notification, context_from_event, get_messages, send_notification
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
https://github.com/mozilla/remote-settings/issues/628
<img width="334" alt="Screenshot 2025-02-05 at 16 59 31" src="https://github.com/user-attachments/assets/2d3ea01a-7247-4ac2-aa40-7a513100e6d8" />


The problem comes from the storage that is used on a committed transaction.

This patch splits the event listener into two parts:
- one that accesses storage to build the message before commit
- one that sends the messages after commit 

